### PR TITLE
Numeric serialization for IPC item transmission

### DIFF
--- a/Models/InventoryItem.cs
+++ b/Models/InventoryItem.cs
@@ -1132,5 +1132,77 @@ namespace CriticalCommonLib.Models
         public virtual void PopulateData(GameData gameData, Language language)
         {
         }
+
+        public static InventoryItem FromNumeric(ulong[] serializedItem)
+        {
+            var gearSetLengh = serializedItem.Length - 24;
+            var gearSets = gearSetLengh > 0 ? new ArraySegment<ulong>(serializedItem, 24, serializedItem.Length - 24).Select(i => (uint)i).ToArray() : null;
+
+            var inventoryItem = new InventoryItem {
+                Container = (InventoryType)serializedItem[0],
+                Slot = (short)serializedItem[1],
+                ItemId = (uint)serializedItem[2],
+                Quantity = (uint)serializedItem[3],
+                Spiritbond = (ushort)serializedItem[4],
+                Condition = (ushort)serializedItem[5],
+                Flags = (FFXIVClientStructs.FFXIV.Client.Game.InventoryItem.ItemFlags)serializedItem[6],
+                Materia0 = (ushort)serializedItem[7],
+                Materia1 = (ushort)serializedItem[8],
+                Materia2 = (ushort)serializedItem[9],
+                Materia3 = (ushort)serializedItem[10],
+                Materia4 = (ushort)serializedItem[11],
+                MateriaLevel0 = (byte)serializedItem[12],
+                MateriaLevel1 = (byte)serializedItem[13],
+                MateriaLevel2 = (byte)serializedItem[14],
+                MateriaLevel3 = (byte)serializedItem[15],
+                MateriaLevel4 = (byte)serializedItem[16],
+                Stain = (byte)serializedItem[17],
+                GlamourId = (uint)serializedItem[18],
+                SortedContainer = (InventoryType)serializedItem[19],
+                SortedCategory = (InventoryCategory)serializedItem[20],
+                SortedSlotIndex = (int)serializedItem[21],
+                RetainerId = (uint)serializedItem[22],
+                RetainerMarketPrice = (uint)serializedItem[23],
+                GearSets = gearSets,
+                // TODO: find a way to restore GearSetNames if the item belongs to active character
+            };
+
+            return inventoryItem;
+        }
+        public ulong[] ToNumeric()
+        {
+            var serializedItem = new ulong[24 + GearSets?.Length ?? 0];
+            serializedItem[0] = (ulong)Container;
+            serializedItem[1] = (ulong)Slot;
+            serializedItem[2] = ItemId;
+            serializedItem[3] = Quantity;
+            serializedItem[4] = Spiritbond;
+            serializedItem[5] = Condition;
+            serializedItem[6] = (ulong)Flags;
+            serializedItem[7] = Materia0;
+            serializedItem[8] = Materia1;
+            serializedItem[9] = Materia2;
+            serializedItem[10] = Materia3;
+            serializedItem[11] = Materia4;
+            serializedItem[12] = MateriaLevel0;
+            serializedItem[13] = MateriaLevel1;
+            serializedItem[14] = MateriaLevel2;
+            serializedItem[15] = MateriaLevel3;
+            serializedItem[16] = MateriaLevel4;
+            serializedItem[17] = Stain;
+            serializedItem[18] = GlamourId;
+            serializedItem[19] = (ulong)SortedContainer;
+            serializedItem[20] = (ulong)SortedCategory;
+            serializedItem[21] = (ulong)SortedSlotIndex;
+            serializedItem[22] = RetainerId;
+            serializedItem[23] = RetainerMarketPrice;
+
+            if (GearSets == null || GearSets.Length == 0) return serializedItem;
+            for (int i = 0; i < GearSets.Length; i++) {
+                serializedItem[24 + i] = GearSets[i];
+            }
+
+            return serializedItem;
+        }
     }
 }


### PR DESCRIPTION
This is the CriticalCommonLib part, the AT part uses the `ToNumeric()` method to send data, the receiving plugin will use `FromNumeric()` to deserialize it.

In case `InventoryItem` changes, the corresponding fields will have to be adjusted, as well as the array length (24).