### PR TITLE
Fix ItemEx ObtainedWithSpecialShopCurrency

### DIFF
--- a/Sheets/ItemEx.cs
+++ b/Sheets/ItemEx.cs
@@ -724,7 +724,7 @@ namespace CriticalCommonLib.Sheets
         {
             if (Service.ExcelCache.SpecialShopItemRewardCostLookup.ContainsKey(RowId))
             {
-                return Service.ExcelCache.SpecialShopItemRewardCostLookup[RowId].Any(c => c.Item1 == currencyItemId);
+                return Service.ExcelCache.SpecialShopItemRewardCostLookup[RowId].Any(c => c.Item2 == currencyItemId);
             }
 
             return false;


### PR DESCRIPTION
I noticed that the "Purchased with Currency" filter in Allagan Tools was not working as expected (e.g. create a game item filter and add a purchased with currency filter for wolf mark, trophy crystal, etc. and strange items or no items will be shown).

I believe the issue is that the currency cost tuple is stored as `(quantity, currencyItemId)` but the filter was checking `Item1` instead of `Item2`. Not sure if the tuple is wrong or the filter is wrong but guessing it's the latter, which is what this fix does. I tested and it seemed to work fine locally.