### PR TITLE
Universalis fixes

### DIFF
--- a/MarketBoard/HostedUniversalis.cs
+++ b/MarketBoard/HostedUniversalis.cs
@@ -192,7 +192,7 @@ public class HostedUniversalis : BackgroundService, IUniversalis
             else
             {
                 MultiRequest? multiRequest = JsonConvert.DeserializeObject<MultiRequest>(value);
-                if (multiRequest != null)
+                if (multiRequest?.items != null)
                 {
                     foreach (var item in multiRequest.items)
                     {

--- a/MarketBoard/HostedUniversalis.cs
+++ b/MarketBoard/HostedUniversalis.cs
@@ -91,6 +91,10 @@ public class HostedUniversalis : BackgroundService, IUniversalis
 
     public void QueuePriceCheck(uint itemId, uint worldId)
     {
+        if (itemId == 0)
+        {
+            return;
+        }
         _queueWorldItemIds.TryAdd(worldId, (DateTime.Now.AddSeconds(QueueTime), []));
         _queueWorldItemIds[worldId].Item2.Add(itemId);
         if (_queueWorldItemIds[worldId].Item2.Count == 50)


### PR DESCRIPTION
I noticed exceptions being logged when the plugin started, so I thought I'll go fix them. 😃

`RetrieveMarketBoardPrices` throws on `multiRequest.items` being null. This happens because it requested an Item with id 0, so Universalis responds with a Not Found response that doesn't include the items array.

To fix this, I made `QueuePriceCheck` ignore requests for ItemId 0.
Additionally I added a null check for the items array - just to be safe.